### PR TITLE
feat: Add support for ARM

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -36,11 +36,17 @@ get_arch() {
 	local arch
 	arch="$(uname -m)"
 
-	if [ "${arch}" == "x86_64" ]; then
-		arch='amd64'
-	fi
-
-	echo "${arch}"
+	case "$arch" in
+		x86_64)
+			echo "amd64"
+			;;
+		aarch64 | arm64)
+			echo "arm64"
+			;;
+		*)
+			fail "Unsupported architecture: $arch"
+			;;
+	esac
 }
 
 download_release() {


### PR DESCRIPTION
This PR adds support for ARM-based systems (e.g., arm64, aarch64) to the asdf-tfcmt plugin. This enhancement allows users on ARM-based machines such as Apple Silicon Macs or ARM Linux servers to install and use tfcmt via the asdf/mise version manager.